### PR TITLE
fix google parsing errors

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -2,4 +2,4 @@
 title: robots
 ---
 User-agent: *
-Sitemap: <{{site.url}}/sitemap.xml>
+Sitemap: <http://{{site.url}}/sitemap.xml>

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -6,12 +6,12 @@ title : Sitemap
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
 {% for post in site.posts %}
     <url>
-        <loc>{{site.url}}{{ post.url }}</loc>
+        <loc>http://{{site.url}}{{ post.url }}</loc>
     </url>
 {% endfor %}
 {% for page in site.pages %}
     <url>
-        <loc>{{site.url}}{{ page.url }}</loc>
+        <loc>http://{{site.url}}{{ page.url }}</loc>
     </url>
 {% endfor %}
 </urlset>


### PR DESCRIPTION
google reports crawling errors because the urls in robots.txt and sitemap.xml do not have a "http://" prepended.