### PR TITLE
Show present job on career with green color

### DIFF
--- a/_data/index/careers.yml
+++ b/_data/index/careers.yml
@@ -27,3 +27,4 @@
     detail: Full Stack Developer
     i18n: company_b_job
   icon: fa-plus-square
+  present: true

--- a/_includes/sections/career.html
+++ b/_includes/sections/career.html
@@ -11,7 +11,7 @@
             {% for career in site.data.index.careers %}
             {% assign loopindex = forloop.index | modulo: 2 %}
                 <div class="vertical-timeline-block">
-                    <div class="vertical-timeline-icon navy-bg wow rotateIn">
+                    <div class="vertical-timeline-icon {% if career.present ==  true %} navy-bg-present {% else %} navy-bg {% endif %} wow rotateIn">
                         <i class="fa {{ career.icon }}"></i>
                     </div>
                     <div class="vertical-timeline-content wow {% if loopindex == 1 %} rotateInUpRight {% else %} rotateInUpLeft {% endif %}">

--- a/_sass/_style.scss
+++ b/_sass/_style.scss
@@ -1434,6 +1434,11 @@ code {
   color: #fff;
 }
 
+.navy-bg-present {
+  background-color: #1cf400;
+  color: #fff;
+}
+
 .panel-primary {
   border-color: #3385FF;
 }


### PR DESCRIPTION
- This feature can change the circle color to green showing that it is the recent work
- Just put "present: true" on careers.yaml

<img width="1088" alt="screen shot 2019-01-25 at 12 48 17" src="https://user-images.githubusercontent.com/18387694/51772165-16d43780-20ca-11e9-8a78-655da3040015.png">
<img width="372" alt="screen shot 2019-01-25 at 12 48 34" src="https://user-images.githubusercontent.com/18387694/51772166-16d43780-20ca-11e9-815c-82c52266afef.png">
<img width="462" alt="screen shot 2019-01-25 at 12 48 56" src="https://user-images.githubusercontent.com/18387694/51772167-176cce00-20ca-11e9-9dc8-20d93bc62115.png">
